### PR TITLE
[CP-1029][Spike] Migrate subset of video "renditions" and generate ap…

### DIFF
--- a/migrationTool/AssetOptionsBinder.cs
+++ b/migrationTool/AssetOptionsBinder.cs
@@ -141,7 +141,7 @@ Visit https://learn.microsoft.com/en-us/azure/media-services/latest/filter-order
         
         private readonly Option<bool> _onlyAssetsWithAlternateId = new(
             aliases: new[] { "--assets-with-alternateId" },
-            () => false,
+            () => true,
             description: @"Only migrate assets where AlternateId is not null or empty.");
 
         const int SegmentDurationInSeconds = 2;

--- a/migrationTool/transform/BasePackager.cs
+++ b/migrationTool/transform/BasePackager.cs
@@ -216,6 +216,14 @@ namespace AMSMigrate.Transform
             // Derived class can override it with its own logic.
             return;
         }
+        
+        public virtual Task AdjustPackageFilesForSupportedResolutions(string workingDirectory,
+            CancellationToken cancellationToken)
+        {
+            // Make it no-op in base class for adjusting package files.
+            // Derived class can override it with its own logic.
+            return Task.CompletedTask;
+        }
 
         private async Task DownloadAsync(string workingDirectory, string file, IList<Track> tracks, CancellationToken cancellationToken)
         {

--- a/migrationTool/transform/PackageTransform.cs
+++ b/migrationTool/transform/PackageTransform.cs
@@ -112,7 +112,7 @@ namespace AMSMigrate.Transform
 
                 // Adjust the package files after the input files are all downloaded.
                 packager.AdjustPackageFiles(workingDirectory);
-                await packager.AdjustPackageFilesForSupportedResolutions(workingDirectory, cancellationToken);
+                //await packager.AdjustPackageFilesForSupportedResolutions(workingDirectory, cancellationToken);
 
                 var outputFiles = packager.Outputs;
                 var (outputContainerName, prefix) = outputPath;

--- a/migrationTool/transform/PackageTransform.cs
+++ b/migrationTool/transform/PackageTransform.cs
@@ -112,6 +112,7 @@ namespace AMSMigrate.Transform
 
                 // Adjust the package files after the input files are all downloaded.
                 packager.AdjustPackageFiles(workingDirectory);
+                await packager.AdjustPackageFilesForSupportedResolutions(workingDirectory, cancellationToken);
 
                 var outputFiles = packager.Outputs;
                 var (outputContainerName, prefix) = outputPath;


### PR DESCRIPTION
…propriate manifest

- Update migration tool to only copy over media with a height of 180,360 and 1080
- By default only copy assets with an alternateId set, this alternateId should map to a MediaValet MediaFileId